### PR TITLE
handle OPTIONS request in a better way

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const app = express();
 const fs = require('fs');
 const path = require('path');
 const bodyParser = require('body-parser');
-const allowedMethods = ['GET', 'POST'];
+const allowedMethods = ['GET', 'POST', 'OPTIONS', 'PUT', 'PATCH', 'DELETE'];
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const app = express();
 const fs = require('fs');
 const path = require('path');
 const bodyParser = require('body-parser');
+const allowedMethods = ['GET', 'POST'];
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
@@ -16,7 +17,7 @@ app.use(function(req, res, next) {
   res.setHeader('Access-Control-Allow-Origin', '*');
 
   // Request methods you wish to allow
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+  res.setHeader('Access-Control-Allow-Methods', allowedMethods.join(', '));
 
   // Request headers you wish to allow
   res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
@@ -83,10 +84,21 @@ app.all('/*', function(req, res) {
 
   console.info('HTTP ' + req.method + ' ' + req.path + ' ' + params);
 
-  // OPTIONS calls don't check for a valid JSON file to load: they always return
-  // a succesful empty JSON response
   if (req.method === 'OPTIONS') {
-    res.json({});
+    let methods = [];
+    allowedMethods.forEach(function(method) {
+      let filePath = path.join(module.exports.apiDataPath, req.path + params + '.' + method + '.json');
+      if(fs.existsSync(filePath)) {
+        methods.push(method);
+      }
+    });
+    if(methods.length) {
+      res.setHeader('Access-Control-Allow-Methods', methods.join(', '));
+      res.send(methods);
+    } else {
+      res.setHeader('Access-Control-Allow-Methods', '');
+      res.status(404).send();
+    }
     return;
   }
 

--- a/test/integration/test-index.js
+++ b/test/integration/test-index.js
@@ -81,10 +81,20 @@ describe('Integration', function() {
       .end(done);
   });
 
-  it('HTTP OPTIONS call', function(done) {
+  it('HTTP OPTIONS call to a wront address', function(done) {
     supertest(app.app)
       .options('/generic/options')
-      .expect(200)
+      .expect(404)
       .end(done);
+  });
+
+  it('HTTP OPTIONS call to a right address', function(done) {
+    supertest(app.app)
+      .options('/call')
+      .expect(200)
+      .end(function(err, response) {
+        assert.ok(!err);
+        return done();
+      });
   });
 });

--- a/test/integration/test-index.js
+++ b/test/integration/test-index.js
@@ -81,7 +81,7 @@ describe('Integration', function() {
       .end(done);
   });
 
-  it('HTTP OPTIONS call to a wront address', function(done) {
+  it('HTTP OPTIONS call to a wrong address', function(done) {
     supertest(app.app)
       .options('/generic/options')
       .expect(404)


### PR DESCRIPTION
Have modified the header `Access-Control-Allow-Methods` to include only GET & POST now. I'm not sure if we need other methods as they don't serve the purpose they're meant for. For example, we're not deleting a resource when we get a DELETE request. This came across my mind when I wanted to send allowed methods for an OPTIONS request. Would like to hear from you on how to go about it.